### PR TITLE
Fix manager names in chart titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -2526,7 +2526,9 @@
                 datasetName = 'All Departments';
             } else {
                 data = allData[selectedDataset] || [];
-                datasetName = selectedDataset.charAt(0).toUpperCase() + selectedDataset.slice(1).replace('-', ' ');
+                datasetName = departmentManagers[selectedDataset] ||
+                    (selectedDataset.charAt(0).toUpperCase() +
+                     selectedDataset.slice(1).replace('-', ' '));
             }
 
             if (data.length === 0) return;


### PR DESCRIPTION
## Summary
- show the full manager name in chart titles by using the department manager mapping

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684125bc60908333a0dc5922e4882fe0