### PR TITLE
Add dev server script and usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Lord of Files Dashboard
+
+This repository contains a static HTML dashboard that visualizes score distributions for different department managers. It uses plain HTML, CSS and JavaScript with no build tools.
+
+## Local Development
+
+You can open `index.html` directly in your browser, but running a tiny HTTP server makes testing easier.
+
+### Using the included Python server
+
+Run the helper script to start a local server from the project root:
+
+```bash
+python3 serve.py
+```
+
+The dashboard will be available at [http://localhost:8000](http://localhost:8000). Use `--port` to change the port or `--dir` to serve a different directory.
+
+### Using Python's built in server directly
+
+Alternatively you can use Python's built-in module:
+
+```bash
+python3 -m http.server 8000
+```
+
+Both approaches serve the files in the current directory so you can view changes in the browser as you edit them.

--- a/serve.py
+++ b/serve.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Simple development server for the static site."""
+import argparse
+from http.server import ThreadingHTTPServer, SimpleHTTPRequestHandler
+from pathlib import Path
+
+
+def run(port: int, directory: Path) -> None:
+    """Start an HTTP server serving the given directory."""
+    directory = directory.resolve()
+    handler_class = SimpleHTTPRequestHandler
+    handler_class.directory = str(directory)
+
+    with ThreadingHTTPServer(('0.0.0.0', port), handler_class) as httpd:
+        print(f"Serving {directory} at http://localhost:{port}")
+        print("Press Ctrl+C to stop.")
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            pass
+        finally:
+            print("Shutting down server")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run a simple HTTP server for local development.")
+    parser.add_argument('-p', '--port', type=int, default=8000, help='Port to listen on (default: 8000).')
+    parser.add_argument('-d', '--dir', dest='directory', type=str, default='.', help='Directory to serve (default: current directory).')
+    args = parser.parse_args()
+    run(args.port, Path(args.directory))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a simple Python server script (`serve.py`) for local testing
- document usage in a new `README.md`

## Testing
- `python3 serve.py --help`
- `python3 serve.py --port 8765 & sleep 1 && curl -I http://localhost:8765/index.html && kill %1`

------
https://chatgpt.com/codex/tasks/task_e_6841e1f2fdf08333bde496e3133f9ef1