### PR TITLE
Animate stats on department change

### DIFF
--- a/index.html
+++ b/index.html
@@ -2399,6 +2399,17 @@
         let currentTableDataset = 'all';
         let searchQuery = '';
 
+        // Store the last displayed statistics for animations
+        let currentStats = {
+            totalUsers: 0,
+            totalScore: 0,
+            avgScore: 0,
+            maxScore: 0,
+            medianScore: 0,
+            zeroScores: 0,
+            zeroScorePercentage: 0
+        };
+
         // Department manager mapping
         const departmentManagers = {
             'bully': 'Bully The Kid',
@@ -2471,6 +2482,38 @@
             return bins;
         }
 
+        // Animate a number from start to end
+        function animateNumber(id, start, end, formatFn, duration = 500) {
+            const el = document.getElementById(id);
+            if (!el) return;
+            const startTime = performance.now();
+
+            function update(now) {
+                const progress = Math.min((now - startTime) / duration, 1);
+                const value = start + (end - start) * progress;
+                el.textContent = formatFn(value);
+                if (progress < 1) requestAnimationFrame(update);
+            }
+
+            requestAnimationFrame(update);
+        }
+
+        // Animate zero score count and percentage
+        function animateZeroScores(startCount, endCount, startPct, endPct, duration = 500) {
+            const el = document.getElementById('zeroScores');
+            const startTime = performance.now();
+
+            function update(now) {
+                const progress = Math.min((now - startTime) / duration, 1);
+                const val = startCount + (endCount - startCount) * progress;
+                const pctVal = startPct + (endPct - startPct) * progress;
+                el.textContent = `${Math.round(val).toLocaleString()} (${pctVal.toFixed(1)}%)`;
+                if (progress < 1) requestAnimationFrame(update);
+            }
+
+            requestAnimationFrame(update);
+        }
+
         // Update statistics
         function updateStats(data) {
             const scores = data.map(item => item.score);
@@ -2486,13 +2529,24 @@
                 ? (sortedScores[sortedScores.length / 2 - 1] + sortedScores[sortedScores.length / 2]) / 2
                 : sortedScores[Math.floor(sortedScores.length / 2)];
 
-            document.getElementById('totalUsers').textContent = totalUsers.toLocaleString();
-            document.getElementById('totalScore').textContent = totalScore.toLocaleString();
-            document.getElementById('avgScore').textContent = avgScore.toFixed(1);
-            document.getElementById('maxScore').textContent = maxScore.toLocaleString();
-            document.getElementById('medianScore').textContent = medianScore.toLocaleString();
-            const zeroScorePercentage = ((zeroScores / totalUsers) * 100).toFixed(1);
-            document.getElementById('zeroScores').textContent = `${zeroScores.toLocaleString()} (${zeroScorePercentage}%)`;
+            const zeroScorePercentage = (zeroScores / totalUsers) * 100;
+
+            animateNumber('totalUsers', currentStats.totalUsers, totalUsers, v => Math.round(v).toLocaleString());
+            animateNumber('totalScore', currentStats.totalScore, totalScore, v => Math.round(v).toLocaleString());
+            animateNumber('avgScore', currentStats.avgScore, avgScore, v => v.toFixed(1));
+            animateNumber('maxScore', currentStats.maxScore, maxScore, v => Math.round(v).toLocaleString());
+            animateNumber('medianScore', currentStats.medianScore, medianScore, v => Math.round(v).toLocaleString());
+            animateZeroScores(currentStats.zeroScores, zeroScores, currentStats.zeroScorePercentage, zeroScorePercentage);
+
+            currentStats = {
+                totalUsers,
+                totalScore,
+                avgScore,
+                maxScore,
+                medianScore,
+                zeroScores,
+                zeroScorePercentage
+            };
         }
 
         // Update top performers table


### PR DESCRIPTION
## Summary
- animate score statistics when changing departments

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841f1dfc3f083338d6a007f6fc53fb6